### PR TITLE
added error message if no root file was identivied

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function(options) {
                 });
 
         } else {
+            gutil.log('gulp-cloudfront:', 'no index file identified in root directory [', options.dirRoot, ']');
             return callback(null, file);
         }
 


### PR DESCRIPTION
I had a hard time figuring out why my cloudfront root object was not updated. An error message like this would help